### PR TITLE
Fix boolean subtraction issue of numpy 1.14.0

### DIFF
--- a/xdgmm/xdgmm.py
+++ b/xdgmm/xdgmm.py
@@ -517,7 +517,7 @@ class XDGMM(BaseEstimator):
         pk = []
         
         not_set_idx = np.nonzero(np.isnan(X))[0]
-        set_idx = np.nonzero(True-np.isnan(X))[0]
+        set_idx = np.nonzero(True^np.isnan(X))[0]
         x = X[set_idx]
         covars = np.copy(self.V)
         


### PR DESCRIPTION
Boolean subtraction is deprecated. This change set replaces boolean subtraction with xor.

Fix #33