### PR TITLE
use 2to3 in setup.py, fixes #35

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup
-import xdgmm
 
 setup(
     name="xdgmm",
@@ -12,6 +11,7 @@ setup(
     long_description=open("README.md").read(),
     package_data={"": ["README.md", "LICENSE"]},
     include_package_data=True,
+    use_2to3=True,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This PR enables the `use_2to3` option in `setup.py` so that the package can be installed in a python 3 environment. 