### PR TITLE
Swap `astroML.utils.logsumexp` for scipy version

### DIFF
--- a/xdgmm/xdgmm.py
+++ b/xdgmm/xdgmm.py
@@ -12,14 +12,15 @@ Allows conditioning of the GMM based on a subset of the parameters.
 """
 
 import numpy as np
-from scipy.stats import multivariate_normal
 import pandas as pd
+
+from scipy.stats import multivariate_normal
+from scipy.special import logsumexp
 
 from sklearn.mixture import GaussianMixture as skl_GMM
 from sklearn.base import BaseEstimator
 
 from astroML.density_estimation import XDGMM as astroML_XDGMM
-from astroML.utils import logsumexp
 
 class XDGMM(BaseEstimator):
     """Extreme Deconvolution


### PR DESCRIPTION
astroML is issuing deprecation warnings for this function; under the hood, it's using the scipy function (and this is the replacement it recommends).

Fixes #46.